### PR TITLE
chore: upgrade ktlint-gradle to 10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ This plugin configures the following tasks for any ekino Kotlin project :
 
 You need to have a JDK 8 at least.
 
-It requires Gradle 6 (6.3 or later).
-Gradle 5.6 is also supported but this support is deprecated and will be removed in a future release.
+It requires Gradle 6.4.1 or later.
 
 ## Usage
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,13 +7,13 @@ plugins {
   id("org.sonarqube") version "3.2.0"
   jacoco
 
-  id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
+  id("org.jlleitschuh.gradle.ktlint") version "10.1.0"
   id("io.gitlab.arturbosch.detekt") version "1.17.1"
   id("com.gradle.plugin-publish") version "0.15.0"
 }
 
 group = "com.ekino.oss.plugin"
-version = "2.1.1"
+version = "3.0.0"
 findProperty("releaseVersion")?.let { version = it }
 
 repositories {
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
   implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.2.0")
-  implementation("org.jlleitschuh.gradle:ktlint-gradle:9.3.0")
+  implementation("org.jlleitschuh.gradle:ktlint-gradle:10.1.0")
   implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.17.1")
 
   testImplementation(gradleTestKit())

--- a/src/test/kotlin/com/ekino/oss/plugin/GradleVersionsCompatibilityTest.kt
+++ b/src/test/kotlin/com/ekino/oss/plugin/GradleVersionsCompatibilityTest.kt
@@ -17,7 +17,7 @@ class GradleVersionsCompatibilityTest {
   @TempDir
   lateinit var tempDir: File
 
-  @ValueSource(strings = ["5.6.4", "6.4.1", "6.5.1", "6.6.1", "6.8.3", "6.9"])
+  @ValueSource(strings = ["6.4.1", "6.5.1", "6.6.1", "6.8.3", "6.9"])
   @ParameterizedTest(name = "Gradle {0}")
   @DisplayName("Should work in Gradle version")
   fun shouldWorkInGradleVersion(gradleVersion: String) {
@@ -25,6 +25,10 @@ class GradleVersionsCompatibilityTest {
       """
       plugins {
           id 'com.ekino.oss.plugin.kotlin-quality'
+      }
+      
+      repositories {
+          mavenCentral()
       }
       """
 


### PR DESCRIPTION
I've also dropped support for Gradle 5 because ktlint-gradle only supports Gradle 6+.